### PR TITLE
chore: upgrade project to Unreal Engine 5.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ Plugins/**/Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*
+
+# Spec workflow
+.spec-workflow/

--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -44,7 +44,7 @@ r.RayTracing.RayTracingProxies.ProjectEnabled=True
 
 [/Script/AndroidRuntimeSettings.AndroidRuntimeSettings]
 bBuildForES31=False
-ExtraApplicationSettings=<meta-data android:name="com.oculus.supportedDevices" android:value="quest2|questpro|quest3" />
+ExtraApplicationSettings=<meta-data android:name="com.oculus.supportedDevices" android:value="quest2|questpro|quest3|quest3s" />
 bPackageForMetaQuest=True
 MinSDKVersion=32
 TargetSDKVersion=32
@@ -165,3 +165,4 @@ ManualIPAddress=
 
 [CoreRedirects]
 +FunctionRedirects=(OldName="/Script/NapOfTheVR.NoteGameInstanceSubsystem.TriggerSpawnModelButtonClicked",NewName="/Script/NapOfTheVR.NoteGameInstanceSubsystem.CallSpawnModelButtonClicked")
+

--- a/Content/VRTemplate/Maps/VRTemplateMap.umap
+++ b/Content/VRTemplate/Maps/VRTemplateMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63d705b469ffcd8416fa4abf8cb1f2d1cdfdcef2bcbe8ca0a7ac2040deb7d450
-size 204897
+oid sha256:ff0a75c65399fed23257a551989294f583598054ae58ec1d98ad80028f475638
+size 204886

--- a/NapOfTheVR.uproject
+++ b/NapOfTheVR.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.6",
+	"EngineAssociation": "5.8",
 	"Category": "",
 	"Description": "",
 	"Modules": [
@@ -41,6 +41,14 @@
 				"Linux",
 				"Android"
 			]
+		},
+		{
+			"Name": "ModelContextProtocol",
+			"Enabled": true
+		},
+		{
+			"Name": "MCPClientToolset",
+			"Enabled": true
 		}
 	],
 	"TargetPlatforms": [

--- a/Source/NapOfTheVR.Target.cs
+++ b/Source/NapOfTheVR.Target.cs
@@ -8,7 +8,8 @@ public class NapOfTheVRTarget : TargetRules
 	public NapOfTheVRTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Game;
-		DefaultBuildSettings = BuildSettingsVersion.V5;
+		DefaultBuildSettings = BuildSettingsVersion.V7;
+		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_8;
 
 		ExtraModuleNames.AddRange( new string[] { "NapOfTheVR" } );
 	}

--- a/Source/NapOfTheVREditor.Target.cs
+++ b/Source/NapOfTheVREditor.Target.cs
@@ -8,7 +8,8 @@ public class NapOfTheVREditorTarget : TargetRules
 	public NapOfTheVREditorTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Editor;
-		DefaultBuildSettings = BuildSettingsVersion.V5;
+		DefaultBuildSettings = BuildSettingsVersion.V7;
+		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_8;
 
 		ExtraModuleNames.AddRange( new string[] { "NapOfTheVR" } );
 	}


### PR DESCRIPTION
## Summary
- Upgrade engine association from UE 5.6 to UE 5.8
- Bump `DefaultBuildSettings` to `BuildSettingsVersion.V7`
- Set `IncludeOrderVersion` to `EngineIncludeOrderVersion.Unreal5_8`
- Enable `ModelContextProtocol` and `MCPClientToolset` plugins
- Add Quest 3S to supported Android devices
- Add `.spec-workflow/` to `.gitignore`

## Test plan
- [x] Build succeeds in UE 5.8
- [x] Open project in UE 5.8 Editor and verify no asset errors
- [x] Test VR preview with OpenXR